### PR TITLE
move state-0 to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
   },
   "homepage": "https://github.com/victor4l/PostIt#readme",
   "devDependencies": {
-    "babel-preset-stage-0": "^6.24.1",
     "browser-sync": "^2.18.12",
     "eslint": "^3.19.0",
     "eslint-config-airbnb": "^15.0.1",
@@ -58,6 +57,7 @@
     "babel-core": "^6.25.0",
     "babel-loader": "^7.0.0",
     "babel-preset-es2015": "^6.24.1",
+    "babel-preset-stage-0": "^6.24.1",
     "babel-preset-react": "^6.24.1",
     "babel-register": "^6.24.1",
     "bcrypt-nodejs": "0.0.3",


### PR DESCRIPTION
#### Description
In this Pull Request, I move babel-preset-stage-0 to dependencies, fixing a bug that causes the application to break in production environment.